### PR TITLE
Add vscode support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Debug CI_gen in example/test",
+        "type": "cppdbg",
+        "request": "launch",
+        "program": "${workspaceFolder}/src/CI_gen",
+        "args": [], // Possible input args for a.out
+        "stopAtEntry": false,
+        "cwd": "${workspaceFolder}/example/test",
+        "environment": [],
+        "externalConsole": false,
+        "preLaunchTask": "cigen:build:debug",
+        "MIMode": "gdb",
+        "setupCommands": [
+          {
+            "description": "Enable pretty-printing for gdb",
+            "text": "-enable-pretty-printing",
+            "ignoreFailures": true
+          }
+        ]
+      }
+    ]
+  }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "fortran.fortls.path": "~/.local/bin/fortls"
+  }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,24 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "cigen:build:debug",
+        "type": "shell",
+        "command": "make debug",
+        "options": {
+            "cwd": "${workspaceFolder}/src"
+        }
+      },
+      {
+        "label": "cigen:build:prod",
+        "type": "shell",
+        "command": "make",
+        "options": {
+            "cwd": "${workspaceFolder}/src"
+        }
+      }
+    ]
+  }
+  

--- a/docs/setup-for-vscode.md
+++ b/docs/setup-for-vscode.md
@@ -1,0 +1,27 @@
+# Set up your environment for vscode
+* Install the "Modern Fortran" extension
+* Install fortls
+* Restart vscode
+<br>
+You can then debug using the "Debug CI_gen in example/test" launch configuration or pressing F5.
+
+## fortls installation
+Prerequisite: python3.7
+```sh
+sudo apt install python3.7
+## Do this if you already have other python versions installed
+sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.7 1
+sudo update-alternatives --config python # then choose 1
+```
+Note: you must install fortls using python3.7
+```sh
+python3.7 -m pip install fortls
+```
+fortls path should be: $HOME/.local/bin/fortls
+Then update .vscode/settings.json with your path
+
+## Additional notes
+You may need to install this dependency:
+```sh
+sudo apt install liblapack-dev
+```

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,6 @@
 # compiler
-FC = gfortran -fopenmp -O3 -fdefault-integer-8 #-Wall -fcheck=all -pg
+FC = gfortran -fopenmp -fdefault-integer-8#-Wall -fcheck=all -pg
+FCDEBUG = gfortran -fopenmp -g -Og -ffpe-trap=invalid,zero,overflow,underflow -fbacktrace -fdefault-integer-8#-Wall -fcheck=all -pg
 
 # compile flags
 FCFLAGS = -c
@@ -11,6 +12,8 @@ PROGS=CI_gen # ao2mo lapack_diag iHj iHj_2 prun randSCI
 
 all : CI_gen clean
 #randSCI ao2mo iHj iHj_2 prun clean
+
+debug : CI_gen_debug
 
 iomod.o : iomod.f90
 	$(FC) $(FCFLAGS) $<
@@ -29,6 +32,9 @@ rbm.o : rbm.f90 tools.o
 
 CI_gen : CI_gen.f90 iomod.o readin.o tools.o var.o rbm.o 
 	$(FC) $^ $(LIB) -o $@
+
+CI_gen_debug : CI_gen.f90 iomod.o readin.o tools.o var.o rbm.o 
+	$(FCDEBUG) $^ $(LIB) -o CI_gen
 
 clean : 
 	rm  *.o *.mod

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,12 +1,13 @@
 # compiler
 FC = gfortran -fopenmp -fdefault-integer-8#-Wall -fcheck=all -pg
-FCDEBUG = gfortran -fopenmp -g -Og -ffpe-trap=invalid,zero,overflow,underflow -fbacktrace -fdefault-integer-8#-Wall -fcheck=all -pg
 
 # compile flags
 FCFLAGS = -c
 # link flags
 FLFLAGS =
 LIB = -lblas -llapack -lstdc++ -lrt -ldl  -lz
+# debug flags
+DEBUGFLAGS = -g -Og -ffpe-trap=invalid,zero,overflow,underflow -fbacktrace
 
 PROGS=CI_gen # ao2mo lapack_diag iHj iHj_2 prun randSCI
 
@@ -34,7 +35,7 @@ CI_gen : CI_gen.f90 iomod.o readin.o tools.o var.o rbm.o
 	$(FC) $^ $(LIB) -o $@
 
 CI_gen_debug : CI_gen.f90 iomod.o readin.o tools.o var.o rbm.o 
-	$(FCDEBUG) $^ $(LIB) -o CI_gen
+	$(FC) $(DEBUGFLAGS) $^ $(LIB) -o CI_gen
 
 clean : 
 	rm  *.o *.mod

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,13 +1,12 @@
 # compiler
-FC = gfortran -fopenmp -fdefault-integer-8#-Wall -fcheck=all -pg
+FC = gfortran -fopenmp -O3 -fdefault-integer-8 #-Wall -fcheck=all -pg
+FCDEBUG = gfortran -fopenmp -g -Og -ffpe-trap=invalid,zero,overflow,underflow -fbacktrace -fdefault-integer-8
 
 # compile flags
 FCFLAGS = -c
 # link flags
 FLFLAGS =
 LIB = -lblas -llapack -lstdc++ -lrt -ldl  -lz
-# debug flags
-DEBUGFLAGS = -g -Og -ffpe-trap=invalid,zero,overflow,underflow -fbacktrace
 
 PROGS=CI_gen # ao2mo lapack_diag iHj iHj_2 prun randSCI
 
@@ -35,7 +34,7 @@ CI_gen : CI_gen.f90 iomod.o readin.o tools.o var.o rbm.o
 	$(FC) $^ $(LIB) -o $@
 
 CI_gen_debug : CI_gen.f90 iomod.o readin.o tools.o var.o rbm.o 
-	$(FC) $(DEBUGFLAGS) $^ $(LIB) -o CI_gen
+	$(FCDEBUG) $^ $(LIB) -o CI_gen
 
 clean : 
 	rm  *.o *.mod


### PR DESCRIPTION
This PR adds a VSCode launch configuration called "Debug CI_gen in example/test" that enables adding breakpoints and debugging, using the "Modern Fortran" extension, which itself relies on gdb and the fortran language server.
Documentation in docs/setup-for-vscode.md